### PR TITLE
correct SVG->PDF page size

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,4 +1,4 @@
-name: unittests
+name: tests-ubuntu
 
 on:
   push:
@@ -44,3 +44,17 @@ jobs:
           ./manage.py migrate
           ./manage.py collectstatic          
           ./manage.py test
+
+  test-dockerimage:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build & Test
+        run: |
+          docker build --tag botgard-dev .
+          docker run --env BOTGARD_RUN_TESTS=1 botgard-dev

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install librsvg2-bin texlive
+          sudo apt-get install librsvg2-bin texlive poppler-utils
 
       - name: Install python dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .~lock*.o*
 
 settings_local.py
+local_config.sh
 
 *.pdf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add libxslt-dev libxml2-dev
 RUN apk add librsvg rsvg-convert
 RUN apk add texmf-dist texlive
 RUN apk add ttf-liberation ttf-linux-libertine
+RUN apk add poppler-utils  # for `pdfinfo`
 
 RUN adduser appuser -D -u 9999
 

--- a/app/BotGard/tests/test_labels_svg.py
+++ b/app/BotGard/tests/test_labels_svg.py
@@ -1,0 +1,66 @@
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Union
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.admindocs.views import simplify_regex
+
+from labels.models import LabelDefinition
+from labels.mass_action import render_mass_labels_action
+from labels.admin import LabelDefinitionAdmin
+from botman.models import BotanicGarden
+
+from .fixtures import create_test_fixtures
+
+
+class TestLabelsSVG(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        create_test_fixtures()
+
+    def test_svg_label_single(self):
+        self.assertTrue(
+            self.client.login(username="User1", password="the-secret"),
+            "failed to log in"
+        )
+
+        response = self.get_label_response(
+            LabelDefinition.objects.get(id_name="A1"),
+            "garden",
+            BotanicGarden.objects.get(name="Garden 1"),
+            "pdf",
+        )
+        self.assert_pdf_size(response.content, [252, 102])
+
+    def assert_pdf_size(self, pdf_data: bytes, expected_size: List[Union[int, float]]):
+        with tempfile.TemporaryDirectory() as path:
+            filename = Path(path) / "label.pdf"
+            filename.write_bytes(pdf_data)
+            result = subprocess.check_output(["pdfinfo", str(filename)]).decode()
+            match = re.match(r".*Page size:\s+(\d+\.?\d*)\sx\s(\d+.?\d*).*", result.replace("\n", " "))
+            if not match:
+                raise AssertionError(f"Page size not found in pdfinfo result: {result}")
+            page_size = [float(g) for g in match.groups()]
+            self.assertEqual(list(expected_size), page_size, "PDF page size does not match")
+
+    def get_label_response(self, label_model: LabelDefinition, object_type: str, object_model, format: str):
+        if isinstance(object_model, list):
+            if object_type == "garden":
+                url = reverse("admin:botman_botanicgarden_changelist")
+            else:
+                url = reverse("admin:individuals_individual_changelist")
+            return self.client.post(
+                url,
+                data={
+                    "action": f"label_{label_model.id_name}_{format}",
+                    "_selected_action": [str(o.pk) for o in object_model],
+                }
+            )
+        else:
+            return self.client.get(
+                reverse(f"labels:{object_type}", args=(label_model.pk, object_model.pk)) + f"?format={format}",
+            )

--- a/app/BotGard/tests/test_labels_svg.py
+++ b/app/BotGard/tests/test_labels_svg.py
@@ -36,7 +36,7 @@ class TestLabelsSVG(TestCase):
         )
         self.assert_pdf_size(response.content, [252, 102])
 
-    def assert_pdf_size(self, pdf_data: bytes, expected_size: List[Union[int, float]]):
+    def assert_pdf_size(self, pdf_data: bytes, expected_size: List[int]):
         with tempfile.TemporaryDirectory() as path:
             filename = Path(path) / "label.pdf"
             filename.write_bytes(pdf_data)
@@ -44,7 +44,7 @@ class TestLabelsSVG(TestCase):
             match = re.match(r".*Page size:\s+(\d+\.?\d*)\sx\s(\d+.?\d*).*", result.replace("\n", " "))
             if not match:
                 raise AssertionError(f"Page size not found in pdfinfo result: {result}")
-            page_size = [float(g) for g in match.groups()]
+            page_size = [int(float(g)) for g in match.groups()]
             self.assertEqual(list(expected_size), page_size, "PDF page size does not match")
 
     def get_label_response(self, label_model: LabelDefinition, object_type: str, object_model, format: str):

--- a/app/labels/svg_to_pdf.py
+++ b/app/labels/svg_to_pdf.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import re
 import codecs
 import random
 
@@ -21,8 +22,18 @@ def convert_svg_to_format(svg_markup, format):
     except UnicodeEncodeError:
         return _convert_svg_to_format_tmpfile(svg_markup, format)
 
+    version = subprocess.check_output(["rsvg-convert", "--version"]).decode()
+    version = tuple(int(g) for g in re.match(r".*(\d+)\.(\d+)\.(\d+).*", version).groups())
+
+    command_args = ["rsvg-convert", "--format", format, "--dpi-x", "300", "--dpi-y", "300"]
+
+    if version <= (2, 45, 0):
+        # fix dpi setting for rsvg-convert below version 2.46
+        # https://gitlab.gnome.org/GNOME/librsvg/-/issues/514
+        command_args += ["--zoom", "0.24"]
+
     proc = subprocess.Popen(
-        ["rsvg-convert", "--format", format, "--zoom", "0.24", "--dpi-x", "300", "--dpi-y", "300"],
+        command_args,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Somehow the generated labels (svg -> pdf) are too small in newer versions of the ??? package. I believe it's to do with `cairo`. 